### PR TITLE
feat: adding endpoint for manual capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 __pycache__
 .coverage
 # For testing
+dynamodb-local-metadata.json
 dynamodb/*.txt
 dynamodb/*.tar.gz
 dynamodb/DynamoDBLocal*

--- a/dynamodb/dynamodb.sha256
+++ b/dynamodb/dynamodb.sha256
@@ -1,1 +1,1 @@
-4b3705c37747b772b317e868986f31b02cf7052cac7a9d536e63811d2972fd4a *dynamodb_local_latest.tar.gz
+fd4ec95c6b947918a9b73b2dc9533cf37e3db313e6abcc4d8d03c034eecc05b1  dynamodb_local_latest.tar.gz

--- a/pinthesky/resource/cameras/__init__.py
+++ b/pinthesky/resource/cameras/__init__.py
@@ -12,6 +12,7 @@ from pinthesky.s3 import generate_presigned_url
 
 
 LATEST_THUMBNAIL = "thumbnail_latest.jpg"
+DEFAULT_VIDEO_DURATION = 30
 
 
 app_context.inject('camera_data', Cameras())
@@ -119,6 +120,26 @@ def start_capture_image(iot_data, thing_name):
         "context": {
             "file_name": LATEST_THUMBNAIL,
             "capture_id": capture_id
+        }
+    })
+    return {
+        "id": capture_id
+    }
+
+
+@api.route("/cameras/:thing_name/captureVideo", methods=["POST"])
+def start_capture_video(iot_data, thing_name):
+    capture_id = str(uuid4())
+    body = json.loads(request.body) if request.body != "" else {}
+    # When requested, we will default to a 30 second buffer.
+    duration = DEFAULT_VIDEO_DURATION
+    if "durationInSeconds" in body:
+        duration = body['durationInSeconds']
+    publish_event(iot_data, thing_name, {
+        "name": "capture_video",
+        "context": {
+            "capture_id": capture_id,
+            "duration": duration,
         }
     })
     return {

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -2,7 +2,7 @@ from botocore.exceptions import ClientError
 from datetime import datetime
 from pinthesky.globals import app_context
 from unittest.mock import MagicMock
-from tests.resources import Resources
+from resources import Resources
 import pytest
 
 

--- a/tests/resources/test_cameras.py
+++ b/tests/resources/test_cameras.py
@@ -76,6 +76,15 @@ def test_camera_crud_workflow(cameras):
     assert cameras('/PitsCamera1/captureImage').code == 200
     assert cameras('/PitsCamera2/captureImage').code == 404
 
+    # Send a capture video request
+    assert cameras(
+        f'/{cam1["thingName"]}/captureVideo',
+        method='POST',
+        body={
+            "durationInSeconds": 20
+        }
+    ).code == 200
+
     # Send a health request
     assert cameras(
         f'/{cam1["thingName"]}/stats',


### PR DESCRIPTION
Adds an endpoint for triggering the `capture_video` event for manual motion videos.